### PR TITLE
Build browser improvements to support wildcards for artifacts and zip paths

### DIFF
--- a/AzureBuildsBrowser/Clients/Models/ArtifactDetails.cs
+++ b/AzureBuildsBrowser/Clients/Models/ArtifactDetails.cs
@@ -2,6 +2,7 @@
 {
     public class ArtifactDetails
     {
+        public int Id { get; set; }
         public string Name { get; set; }
         public ArtifactResource Resource { get; set; }
     }

--- a/AzureBuildsBrowser/Controllers/ProxyController.cs
+++ b/AzureBuildsBrowser/Controllers/ProxyController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AzureBuildsBrowser.Clients;
 using AzureBuildsBrowser.Clients.Models;
 using AzureBuildsBrowser.Models;
+using AzureBuildsBrowser.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.StaticFiles;
 
@@ -28,7 +29,7 @@ namespace AzureBuildsBrowser.Controllers
             var tags = await tagsTask;
             var lastBuilds = await buildTask;
 
-            return View(new RootModel {Tags = tags, LastBuilds = lastBuilds});
+            return View(new RootModel { Tags = tags, LastBuilds = lastBuilds });
         }
 
         [Route("azdevops/t/{tag}")]
@@ -100,37 +101,37 @@ namespace AzureBuildsBrowser.Controllers
             });
         }
 
-        [Route("azdevops/t/{tag}/r/{repository}/a/{artifactName}/f/{fileName}")]
-        public async Task<IActionResult> File(string tag, string repository, string artifactName, string fileName)
+        [Route("azdevops/t/{tag}/r/{repository}/a/{artifactName}/f/{**filePath}")]
+        public async Task<IActionResult> File(string tag, string repository, string artifactName, string filePath)
         {
             var build = await GetLastBuild(tag, repository);
             if (build == null)
                 return NotFound();
 
-            return await ReturnZipFile(build.Id, artifactName, fileName);
+            return await ReturnZipFile(build.Id, artifactName, filePath);
         }
 
-        [Route("azdevops/b/{buildId}/a/{artifactName}/f/{fileName}")]
-        public async Task<IActionResult> PinnedFile(int buildId, string artifactName, string fileName)
+        [Route("azdevops/b/{buildId}/a/{artifactName}/f/{**filePath}")]
+        public async Task<IActionResult> PinnedFile(int buildId, string artifactName, string filePath)
         {
-            return await ReturnZipFile(buildId, artifactName, fileName);
+            return await ReturnZipFile(buildId, artifactName, filePath);
         }
 
-        private async Task<IActionResult> ReturnZipFile(int buildId, string artifactName, string fileName)
+        private async Task<IActionResult> ReturnZipFile(int buildId, string artifactName, string filePath)
         {
-            fileName = Uri.UnescapeDataString(fileName);
-
             var artifact = await _client.GetArtifact(buildId, artifactName);
             if (artifact == null)
                 return NotFound();
 
             var zip = await _client.DownloadZipFile(artifact.Resource.DownloadUrl);
-            var entry = zip.Entries.FirstOrDefault(x =>
-                string.Equals(x.FullName, fileName, StringComparison.OrdinalIgnoreCase));
+            var pathRegex = PathGlob.Create(filePath);
+            var entry = zip.Entries
+                .OrderByDescending(e => e.LastWriteTime)
+                .FirstOrDefault(x => pathRegex.IsMatch(x.FullName));
             if (entry == null)
                 return NotFound();
 
-            var contentType = _contentTypeProvider.TryGetContentType(fileName, out var c) ? c : "application/octet-stream";
+            var contentType = _contentTypeProvider.TryGetContentType(filePath, out var c) ? c : "application/octet-stream";
             return File(entry.Open(), contentType);
         }
 

--- a/AzureBuildsBrowser/Utils/PathGlob.cs
+++ b/AzureBuildsBrowser/Utils/PathGlob.cs
@@ -1,0 +1,13 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AzureBuildsBrowser.Utils
+{
+    class PathGlob
+    {
+        private static readonly char[] Wildcards = new[] { '*' };
+
+        public static Regex Create(string path) => new Regex("^" + Regex.Escape(path).Replace("\\*", "[^/]*") + "$", RegexOptions.IgnoreCase);
+
+        public static bool HasWildcards(string path) => path.IndexOfAny(Wildcards) >= 0;
+    }
+}

--- a/AzureBuildsBrowser/Views/Proxy/Artifact.cshtml
+++ b/AzureBuildsBrowser/Views/Proxy/Artifact.cshtml
@@ -13,6 +13,6 @@
 @foreach (var file in Model.Zip.Entries)
 {
     <div>
-        <a href="/azdevops/t/@Model.Tag/r/@Model.Repository/a/@Model.Artifact/f/@Uri.EscapeDataString(file.FullName)">@file.FullName</a>
+        <a href="/azdevops/t/@Model.Tag/r/@Model.Repository/a/@Model.Artifact/f/@file.FullName">@file.FullName</a>
     </div>
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Update `appsettings.json` and set:
 } 
 ```
 
+as well as `AzureAd` section.
+
 Compile and run.
 
 ## Supported pages
@@ -31,3 +33,20 @@ Compile and run.
 |`/b/{buildId}/a/{artifact}`|List of files in `{artifact}` for build `{buildId}`|
 |`/t/{tag}/r/{repository}/a/{artifact}/f/{filePath}`|Displays the file content of `{filePath}` from `{artifact}` for build from `{repository}` with `{tag}`|
 |`/b/{buildId}/a/{artifact}/f/{filePath}`|Displays the file content of `{filePath}` from `{artifact}` for build `{buildId}`|
+
+## Globbing
+
+### Artifacts
+It is possible to select artifact name using `*` wildcard. The artifact with matching name and the highest ID will get selected, where the intention of using ID ordering is to pick up the lastest matching file.
+
+The solution is designed to be working with multiple stage reruns that generates artifacts of the same type with different suffixes, like:
+* `tests-attempt1`
+* `tests-attempt2`
+
+Specifying `tests-*` will match the one with highest ID, hopefully `tests-attempt2`.
+
+### Zip file content
+It is possible to navigate through the zip file content and use `*` to select a file with latest lastWrite date.
+The `*` can be used to match path fragments, but it won't work to match path separator, i.e. `/`.
+
+Example usage: `/t/my-tag/r/my-repo/a/tests-attempt*/f/tests-attempt*/*.html`


### PR DESCRIPTION
+ Updated root page to display latest builds ordered by finish time
+ Added option to refer to artifacts using *, where the matching one of the highest ID will get returned
+ Added option to navigate through zip artifacts using / directory navigation
+ Added support for * glob on zip content path segment, returning the file with matching path and latest lastWrite time